### PR TITLE
Fix crew manifest & records

### DIFF
--- a/code/datums/records/manifest.dm
+++ b/code/datums/records/manifest.dm
@@ -18,7 +18,7 @@ GLOBAL_DATUM_INIT(manifest, /datum/manifest, new)
 			log_manifest(readied_player.ckey, readied_player.new_character.mind, readied_player.new_character)
 			players_to_log[readied_player.ckey] = readied_player.new_character
 		if(ishuman(readied_player.new_character))
-			inject(readied_player.new_character)
+			inject(readied_player.new_character, person_client = readied_player.client) // EXOSTATION EDIT CHANGE - CHAR_LORE : addition de  person_client = readied_player.client
 		CHECK_TICK
 	if(length(players_to_log))
 		SSblackbox.ReportRoundstartManifest(players_to_log)


### PR DESCRIPTION
## Contenu des modifications apportées

/datum/manifest/proc/build() : ajout d'un argument pour permettre que les records et le crew manifest fonctionnent avec l'injection des éléments personnalisés de l'onglet Lore de la création de personnage.

## Intérêt pour l'expérience de jeu/de roleplay

Réparer les records personnalisés et le crew manifest.

## Modularité

Non modulaire.

## Preuves de test

<details>
<summary>Screenshots/Vidéos</summary>

</details>

## Changelog

:cl:
fix: Les records et le crew manifest fonctionnent de nouveau pour les joueurs prêts au début du round.
/:cl: