### PR TITLE
Bouton changelog pour TG

### DIFF
--- a/modular_exostation/changelog/code/exo_changelog.dm
+++ b/modular_exostation/changelog/code/exo_changelog.dm
@@ -23,6 +23,10 @@ GLOBAL_VAR_INIT(exo_changelog_hash, "")
 			exo_changelog_item = new /datum/asset/exo_changelog_item(params["date"])
 			exo_changelog_items[params["date"]] = exo_changelog_item
 		return ui.send_asset(exo_changelog_item)
+	if(action == "open_tg_log") // action supplémentaire : bouton vers TG changelog.
+		var/mob/user = ui.user
+		user.client.changelog()
+		return TRUE
 
 /datum/exo_changelog/ui_static_data()
 	var/list/data = list( "dates" = list() )

--- a/modular_exostation/changelog/readme.md
+++ b/modular_exostation/changelog/readme.md
@@ -36,4 +36,4 @@ Tous les fichiers changés ou créés pour l'arborescence de base du repository 
 ### Crédits :
 
 Thravalgur
-Port de fonctionnalités des codebases Bandastation (Maxiemar) et FulpStation (QuiteLiterallyAnything, FernandoJ8), adaptation du changelog de /tg/ (celotajstg)
+Port de fonctionnalités des codebases Bandastation (Maxiemar) et FulpStation (QuiteLiterallyAnything, FernandoJ8, JohnFulpWillard), adaptation du changelog de /tg/ (celotajstg)

--- a/tgui/packages/tgui/interfaces/ExoChangelog.jsx
+++ b/tgui/packages/tgui/interfaces/ExoChangelog.jsx
@@ -116,6 +116,7 @@ export class ExoChangelog extends Component {
   render() {
     const { data, selectedDate, selectedIndex } = this.state;
     const {
+      act,
       data: { dates },
     } = useBackend();
     const { dateChoices } = this;
@@ -214,9 +215,23 @@ export class ExoChangelog extends Component {
         <p>
           <b>Remarque : </b>
           Ce changelog est un quasi-clone de celui de /tg/station, destiné à
-          suivre les évolutions propres au serveur Exostaton. Le changelog de
-          /TG/ peut être trouvé dans le menu Echap ou dans l&apos;onglet OOC
-          avec le verbe /TG/ Changelog.
+          suivre les évolutions propres au serveur Exostaton.
+          <br />
+          Tout changement qui ne figure pas ici vient probablement de
+          modifications effectuées sur le code original de /tg/station.
+          <br />
+          Le changelog de /TG/ peut être trouvé dans le menu Echap ou dans
+          l&apos;onglet OOC avec le verbe /TG/ Changelog ou en{' '}
+          <Button
+            mx={-0.5}
+            compact
+            textColor="blue"
+            color="transparent"
+            onClick={() => act('open_tg_log')}
+          >
+            cliquant ici
+          </Button>
+          .
         </p>
         {dateDropdown}
       </Section>
@@ -250,8 +265,9 @@ export class ExoChangelog extends Component {
           <b>Remerciements aux autres downstreams : </b>
           Merci aux développeurs de BandaStation, Skyrat Station 13, Nova
           Sector, IrisStation, BubberStation, MappleStation, Orbstation,
-          DopplerStation et TaleStation, ainsi que de tout autre downstream dont
-          les idées ou le travail ont inspiré les développeurs d'Exostation.
+          DopplerStation, FulpStation et TaleStation, ainsi que de tout autre
+          downstream dont les idées ou le travail ont inspiré les développeurs
+          d'Exostation.
         </p>
       </Section>
     );


### PR DESCRIPTION
## Contenu des modifications apportées

Ajoute un bouton permettant d'ouvrir le changelog de TG depuis le changelog d'Exostation.
Copie de la fonctionnalité de Fulpstation : https://github.com/fulpstation/fulpstation/pull/1446 

## Intérêt pour l'expérience de jeu/de roleplay

Meilleur fluidité dans le suivi des modifications.

## Modularité

Semi modulaire.

## Preuves de test
<details>
<summary>Screenshots/Vidéos</summary>
<img width="669" height="667" alt="image" src="https://github.com/user-attachments/assets/637bae6b-2133-4e23-b205-ad3dfcb80f0a" />
<img width="994" height="697" alt="image" src="https://github.com/user-attachments/assets/a3c3e27e-cc26-4f9a-95ca-d4928a75d145" />

</details>

## Changelog

Rien qui nécessite une notification dans le changelog.